### PR TITLE
INFRA-8936 | Update GitHub workflows to use App tokens

### DIFF
--- a/.github/workflows/mysql-version-check.yml
+++ b/.github/workflows/mysql-version-check.yml
@@ -1,19 +1,21 @@
 name: Block MySQL 5.x Usage
-
 on:
   pull_request:
     branches:
       - develop
-
 jobs:
   mysql-check:
     runs-on:
       labels: self-hosted
-
     steps:
+      - name: Create GitHub App token
+        id: github-app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.InsiderActionsApplication_APP_ID }}
+          private-key: ${{ secrets.InsiderActionsApplication_PRIVATE_KEY }}
       - name: Checkout code
         uses: actions/checkout@v4
-
       - name: Check for MySQL 5.x
         run: |
           echo "Scanning for MySQL 5.x usage..."


### PR DESCRIPTION
This PR updates GitHub workflows to use GitHub App tokens instead of classic tokens for better security.

## Changes
- Updated actions/checkout and other actions to use GitHub App tokens
- Removed legacy token parameters from workflow files
- Added GitHub App token generation step to workflows

## Auto-assigned Reviewers
Reviewers have been automatically assigned based on recent contributors to the modified files.