### PR TITLE
fix: resolve Gemfile.lock Dependabot security alerts

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,7 +5,7 @@ GEM
       base64
       nkf
       rexml
-    activesupport (7.2.2.1)
+    activesupport (7.2.3.1)
       base64
       benchmark (>= 0.3)
       bigdecimal
@@ -14,11 +14,11 @@ GEM
       drb
       i18n (>= 1.6, < 2)
       logger (>= 1.4.2)
-      minitest (>= 5.1)
+      minitest (>= 5.1, < 6)
       securerandom (>= 0.3)
       tzinfo (~> 2.0, >= 2.0.5)
-    addressable (2.8.7)
-      public_suffix (>= 2.0.2, < 7.0)
+    addressable (2.9.0)
+      public_suffix (>= 2.0.2, < 8.0)
     algoliasearch (1.27.5)
       httpclient (~> 2.8, >= 2.8.3)
       json (>= 1.5.1)
@@ -89,7 +89,7 @@ GEM
     netrc (0.11.0)
     nkf (0.2.0)
     public_suffix (4.0.7)
-    rexml (3.4.1)
+    rexml (3.4.4)
     ruby-macho (2.5.1)
     securerandom (0.4.1)
     typhoeus (1.4.1)
@@ -114,7 +114,7 @@ DEPENDENCIES
   xcodeproj (< 1.26.0)
 
 RUBY VERSION
-   ruby 3.4.1p0
+   ruby 3.4.5p51
 
 BUNDLED WITH
    2.6.9


### PR DESCRIPTION
## Summary
Resolves the **3 remaining open Dependabot alerts** on `Gemfile.lock`:

| Gem | From | To | Alert |
|---|---|---|---|
| addressable | 2.8.7 | 2.9.0 | high — ReDoS in Addressable templates |
| activesupport | 7.2.2.1 | 7.2.3.1 | 3× medium — XSS in SafeBuffer#%, ReDoS/DoS in number helpers |
| rexml | 3.4.1 | 3.4.4 | low — DoS parsing malformed XML |

Done via `bundle update --conservative addressable activesupport rexml` — only the three flagged gems moved; no collateral dependency bumps, `Gemfile` itself untouched (existing cocoapods/activesupport exclusions preserved). The `RUBY VERSION` line moved 3.4.1p0 → 3.4.5p51 as a side effect of the local Ruby used to re-lock.

## Verification
- ✅ `bundle exec pod install` → 81 pods installed (cocoapods is the main consumer of addressable/activesupport)
- ✅ iOS: `xcodebuild -scheme ReactNativeDemo -configuration Debug` (simulator) → BUILD SUCCEEDED

## Notes
- Companion to #23 (npm-side alerts). Together they close all 29 open Dependabot alerts.
- Repo note: `.ruby-version` is gitignored but required by the `Gemfile` — without a local copy, `bundle` fails on a fresh clone. Worth documenting in the README.

## Rollback
Lockfile-only change; revert the PR to roll back.

## Task IDs
https://winsider.atlassian.net/browse/MOB-27016
https://winsider.atlassian.net/browse/MOB-27075

🤖 Generated with [Claude Code](https://claude.com/claude-code)