### PR TITLE
MOB-27407: Add App Cards demo section

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -42,6 +42,7 @@ import PageVisit from "./src/insider/PageVisit";
 import GDPR from "./src/insider/GDPR";
 import MobileAppAccess from "./src/insider/MobileAppAccess";
 import MessageCenter from "./src/insider/MessageCenter";
+import AppCards from "./src/insider/AppCards";
 import ContentOptimizer from "./src/insider/ContentOptimizer";
 import ReinitWithPartnerName from "./src/insider/ReinitWithPartnerName";
 import BlockInApps from "./src/insider/BlockInApps";
@@ -264,6 +265,10 @@ function App() {
 
             <CustomSection title="Message Center">
               <MessageCenter />
+            </CustomSection>
+
+            <CustomSection title="App Cards">
+              <AppCards />
             </CustomSection>
 
             <CustomSection title="Content Optimizer">

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@react-native-async-storage/async-storage": "^2.1.2",
-        "react": "^19.2.3",
+        "react": "19.1.1",
         "react-native": "^0.82.1",
         "react-native-insider": "8.0.0",
         "react-native-safe-area-context": "^5.6.2",
@@ -27,12 +27,12 @@
         "@react-native/metro-config": "^0.82.1",
         "@react-native/typescript-config": "^0.82.1",
         "@types/jest": "^30.0.0",
-        "@types/react": "^19.2.7",
+        "@types/react": "^19.1.1",
         "@types/react-test-renderer": "19.1.0",
         "eslint": "^8.57.1",
         "jest": "^30.2.0",
         "prettier": "^3.7.0",
-        "react-test-renderer": "^19.2.3",
+        "react-test-renderer": "19.1.1",
         "typescript": "^5.9.3"
       },
       "engines": {
@@ -11559,9 +11559,9 @@
       }
     },
     "node_modules/react": {
-      "version": "19.2.5",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
-      "integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
+      "version": "19.1.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.1.1.tgz",
+      "integrity": "sha512-w8nqGImo45dmMIfljjMwOGtbmC/mk4CMYhWIicdSflH91J9TyCyczcPFXJzrZ/ZXcgGRFeP6BU0BEJTw6tZdfQ==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -12095,30 +12095,23 @@
       }
     },
     "node_modules/react-test-renderer": {
-      "version": "19.2.5",
-      "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-19.2.5.tgz",
-      "integrity": "sha512-kwViRpdISMTpcpy5B6TSewfJzRjnajihRaj57ZmOWKD+SPN6k9LUM13O0pfOuW8ir6B6OOiAXwCRqOoVxRNykA==",
+      "version": "19.1.1",
+      "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-19.1.1.tgz",
+      "integrity": "sha512-aGRXI+zcBTtg0diHofc7+Vy97nomBs9WHHFY1Csl3iV0x6xucjNYZZAkiVKGiNYUv23ecOex5jE67t8ZzqYObA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "react-is": "^19.2.5",
-        "scheduler": "^0.27.0"
+        "react-is": "^19.1.1",
+        "scheduler": "^0.26.0"
       },
       "peerDependencies": {
-        "react": "^19.2.5"
+        "react": "^19.1.1"
       }
     },
     "node_modules/react-test-renderer/node_modules/react-is": {
       "version": "19.2.5",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.5.tgz",
       "integrity": "sha512-Dn0t8IQhCmeIT3wu+Apm1/YVsJXsGWi6k4sPdnBIdqMVtHtv0IGi6dcpNpNkNac0zB2uUAqNX3MHzN8c+z2rwQ==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/react-test-renderer/node_modules/scheduler": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
-      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@react-native-async-storage/async-storage": "^2.1.2",
-    "react": "^19.2.3",
+    "react": "19.1.1",
     "react-native": "^0.82.1",
     "react-native-insider": "8.0.0",
     "react-native-safe-area-context": "^5.6.2",
@@ -31,12 +31,12 @@
     "@react-native/metro-config": "^0.82.1",
     "@react-native/typescript-config": "^0.82.1",
     "@types/jest": "^30.0.0",
-    "@types/react": "^19.2.7",
+    "@types/react": "^19.1.1",
     "@types/react-test-renderer": "19.1.0",
     "eslint": "^8.57.1",
     "jest": "^30.2.0",
     "prettier": "^3.7.0",
-    "react-test-renderer": "^19.2.3",
+    "react-test-renderer": "19.1.1",
     "typescript": "^5.9.3"
   },
   "engines": {

--- a/src/insider/AppCards.tsx
+++ b/src/insider/AppCards.tsx
@@ -1,0 +1,536 @@
+import React, { useState, useEffect, useCallback, useRef } from "react";
+import {
+  Text,
+  View,
+  Modal,
+  Image,
+  ScrollView,
+  FlatList,
+  StyleSheet,
+  TouchableOpacity,
+  Alert,
+  ViewToken,
+  useColorScheme,
+} from "react-native";
+import { SafeAreaProvider, SafeAreaView, initialWindowMetrics } from "react-native-safe-area-context";
+
+import CustomButton from "../components/CustomButton";
+import Insider from "react-native-insider";
+import {
+  InsiderAppCard,
+  InsiderAppCardAction,
+  InsiderAppCardDeeplinkAction,
+} from "react-native-insider/src/InsiderAppCard";
+
+// Palette aligned with the rest of the demo (App.tsx Colors + the button
+// color overrides used in the other sections: coral = destructive like Logout,
+// blue = accent like Sign Up).
+const Colors = {
+  white: "#FFFFFF",
+  black: "#000000",
+  light: "#F3F3F3",
+  dark: "#333333",
+  coral: "#E57F74",
+  blue: "#007BFF",
+};
+
+// Logs the action attached to a card or button, expanding deeplink details.
+// Field/method names mirror the native SDK surface (mobileandroid / mobile-ios).
+const logCardAction = (prefix: string, action?: InsiderAppCardAction | null) => {
+  if (!action) {
+    console.log(`${prefix} - no action`);
+    return;
+  }
+
+  console.log(`${prefix} - type=${action.type}`);
+
+  if (action.type === "deep_link") {
+    const deeplink = action as InsiderAppCardDeeplinkAction;
+    console.log(`${prefix} - deeplinkType=${deeplink.deeplinkType} url=${deeplink.url}`);
+    if (deeplink.keysAndValues && deeplink.keysAndValues.length > 0) {
+      console.log(`${prefix} - keysAndValues=${JSON.stringify(deeplink.keysAndValues)}`);
+    }
+    if (deeplink.json !== null && deeplink.json !== undefined) {
+      console.log(`${prefix} - json=${JSON.stringify(deeplink.json)}`);
+    }
+  }
+};
+
+const AppCardItem = ({
+  item,
+  isDarkMode,
+  onOpenDetail,
+  onToggleRead,
+  onDelete,
+}: {
+  item: InsiderAppCard;
+  isDarkMode: boolean;
+  onOpenDetail: (item: InsiderAppCard) => void;
+  onToggleRead: (item: InsiderAppCard) => void;
+  onDelete: (item: InsiderAppCard) => void;
+}) => {
+  const confirmDelete = () => {
+    Alert.alert("Delete Message", "Are you sure you want to delete this message?", [
+      { text: "Cancel", style: "cancel" },
+      { text: "Delete", style: "destructive", onPress: () => onDelete(item) },
+    ]);
+  };
+
+  const titleColor = isDarkMode ? Colors.white : Colors.black;
+  const bodyColor = isDarkMode ? Colors.light : Colors.dark;
+
+  return (
+    <TouchableOpacity onPress={() => onOpenDetail(item)} onLongPress={confirmDelete}>
+      <View
+        style={[
+          styles.card,
+          {
+            backgroundColor: isDarkMode ? Colors.black : Colors.white,
+            borderBottomColor: isDarkMode ? Colors.dark : Colors.light,
+          },
+        ]}
+      >
+        <View style={styles.cardHeader}>
+          {!item.isRead && <View style={styles.unreadIndicator} />}
+          <Text style={[styles.cardTitle, { color: titleColor }]}>
+            {item.content?.title ?? "No Title"}
+          </Text>
+        </View>
+        <Text style={[styles.cardBody, { color: bodyColor }]} numberOfLines={2}>
+          {item.content?.description ?? "No Description"}
+        </Text>
+
+        <View style={styles.buttonRow}>
+          <CustomButton
+            text={item.isRead ? "Mark Unread" : "Mark Read"}
+            onPress={() => onToggleRead(item)}
+          />
+          <CustomButton
+            text="Delete"
+            buttonStyle={{ backgroundColor: Colors.coral }}
+            onPress={confirmDelete}
+          />
+        </View>
+      </View>
+    </TouchableOpacity>
+  );
+};
+
+// Full-screen modal chrome shared by the App Cards inbox and the card detail
+// view: a themed SafeAreaView with a header (title + Close). SafeAreaProvider is
+// re-established here because the safe-area context does not cross the Modal
+// boundary on iOS.
+const ModalScreen = ({
+  visible = true,
+  title,
+  isDarkMode,
+  onClose,
+  children,
+}: {
+  visible?: boolean;
+  title: string;
+  isDarkMode: boolean;
+  onClose: () => void;
+  children: React.ReactNode;
+}) => (
+  <Modal visible={visible} animationType="slide" presentationStyle="fullScreen" onRequestClose={onClose}>
+    <SafeAreaProvider initialMetrics={initialWindowMetrics}>
+      <SafeAreaView
+        style={[styles.modalContainer, { backgroundColor: isDarkMode ? Colors.black : Colors.white }]}
+        edges={["top", "bottom"]}
+      >
+        <View style={[styles.modalHeader, { borderBottomColor: isDarkMode ? Colors.dark : Colors.light }]}>
+          <Text style={[styles.modalTitle, { color: isDarkMode ? Colors.white : Colors.black }]}>
+            {title}
+          </Text>
+          <TouchableOpacity
+            style={styles.closeButton}
+            onPress={onClose}
+            hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+          >
+            <Text style={[styles.closeIcon, { color: isDarkMode ? Colors.white : Colors.black }]}>✕</Text>
+          </TouchableOpacity>
+        </View>
+        {children}
+      </SafeAreaView>
+    </SafeAreaProvider>
+  </Modal>
+);
+
+// Full-screen detail view, rendered inside the shared ModalScreen chrome so it
+// matches the App Cards inbox (same header + Close) and the rest of the demo.
+const CardDetail = ({
+  card,
+  isDarkMode,
+  onClose,
+  onToggleRead,
+  onDelete,
+}: {
+  card: InsiderAppCard;
+  isDarkMode: boolean;
+  onClose: () => void;
+  onToggleRead: (item: InsiderAppCard) => void;
+  onDelete: (item: InsiderAppCard) => void;
+}) => {
+  const titleColor = isDarkMode ? Colors.white : Colors.black;
+  const bodyColor = isDarkMode ? Colors.light : Colors.dark;
+  const dividerColor = isDarkMode ? Colors.dark : Colors.light;
+  const imageUrl = card.images && card.images.length > 0 ? card.images[0].url : null;
+
+  return (
+    <ModalScreen title="Message" isDarkMode={isDarkMode} onClose={onClose}>
+      <ScrollView contentContainerStyle={styles.detailScroll}>
+        {imageUrl && (
+          <Image source={{ uri: imageUrl }} style={styles.detailImage} resizeMode="cover" />
+        )}
+        <Text style={[styles.detailTitle, { color: titleColor }]}>
+          {card.content?.title ?? "No Title"}
+        </Text>
+        <Text style={[styles.detailBody, { color: bodyColor }]}>
+          {card.content?.description ?? "No Description"}
+        </Text>
+
+        {card.buttons && card.buttons.length > 0 && (
+          <View style={styles.detailCardButtons}>
+            {card.buttons.map((button) => (
+              <CustomButton
+                key={button.buttonId}
+                text={button.text}
+                buttonStyle={{ backgroundColor: Colors.blue }}
+                onPress={() => {
+                  logCardAction(
+                    `[INSIDER][AppCardButtonClick]: card=${button.appCardId} button=${button.buttonId}`,
+                    button.action
+                  );
+                  button.click();
+                }}
+              />
+            ))}
+          </View>
+        )}
+      </ScrollView>
+
+      <View style={[styles.detailFooter, { borderTopColor: dividerColor }]}>
+        {card.action && (
+          <View style={styles.buttonRow}>
+            <CustomButton
+              text="Open"
+              onPress={() => {
+                logCardAction(`[INSIDER][AppCardItemClick]: card=${card.appCardId}`, card.action);
+                card.click();
+              }}
+            />
+          </View>
+        )}
+        <View style={styles.buttonRow}>
+          <CustomButton
+            text={card.isRead ? "Mark Unread" : "Mark Read"}
+            onPress={() => {
+              onToggleRead(card);
+              onClose();
+            }}
+          />
+          <CustomButton
+            text="Delete"
+            buttonStyle={{ backgroundColor: Colors.coral }}
+            onPress={() => {
+              onDelete(card);
+              onClose();
+            }}
+          />
+        </View>
+      </View>
+    </ModalScreen>
+  );
+};
+
+// The App Cards inbox. Mounted only while the modal is open, so campaigns are
+// fetched on open rather than on app start.
+const AppCardsInbox = ({ isDarkMode }: { isDarkMode: boolean }) => {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+  const [messages, setMessages] = useState<InsiderAppCard[]>([]);
+  const [selectedCard, setSelectedCard] = useState<InsiderAppCard | null>(null);
+
+  const stateTextColor = { color: isDarkMode ? Colors.light : Colors.dark };
+
+  // Single source of truth for loading campaigns into state; callers layer
+  // their own loading/error handling on top (full-screen on first load,
+  // silent-with-Alert on refresh after a mutation).
+  const fetchCampaigns = useCallback(async () => {
+    const inbox = await Insider.appCards.getCampaigns();
+    const cards = inbox?.appCards ?? [];
+    console.log("[INSIDER][AppCards]: Received " + cards.length + " cards");
+    setMessages(cards);
+  }, []);
+
+  const refreshMessages = useCallback(async () => {
+    try {
+      await fetchCampaigns();
+    } catch (err) {
+      console.log("[INSIDER][AppCards]: Error loading cards: " + err);
+    }
+  }, [fetchCampaigns]);
+
+  useEffect(() => {
+    setLoading(true);
+    fetchCampaigns()
+      .catch((err) => {
+        console.log("[INSIDER][AppCards]: Error loading cards: " + err);
+        setError(err instanceof Error ? err : new Error("Unknown error."));
+      })
+      .finally(() => setLoading(false));
+  }, [fetchCampaigns]);
+
+  const handleOpenDetail = useCallback((item: InsiderAppCard) => {
+    console.log("[INSIDER][AppCardItem]: Opening detail: " + item.appCardId);
+    setSelectedCard(item);
+  }, []);
+
+  const handleToggleRead = useCallback(
+    async (item: InsiderAppCard) => {
+      try {
+        if (item.isRead) {
+          console.log("[INSIDER][AppCardItem]: Marking card as unread: " + item.appCardId);
+          await item.markAsUnread();
+        } else {
+          console.log("[INSIDER][AppCardItem]: Marking card as read: " + item.appCardId);
+          await item.markAsRead();
+        }
+        await refreshMessages();
+      } catch (err) {
+        const action = item.isRead ? "unread" : "read";
+        console.log("[INSIDER][AppCardItem]: Error marking as " + action + ": " + err);
+        Alert.alert("Error", err instanceof Error ? err.message : "Failed to update message status");
+      }
+    },
+    [refreshMessages]
+  );
+
+  const handleDelete = useCallback(
+    async (item: InsiderAppCard) => {
+      try {
+        console.log("[INSIDER][AppCardItem]: Deleting card: " + item.appCardId);
+        await item.delete();
+        Alert.alert("Success", "Message deleted");
+        await refreshMessages();
+      } catch (err) {
+        console.log("[INSIDER][AppCardItem]: Error deleting card: " + err);
+        Alert.alert("Error", err instanceof Error ? err.message : "Failed to delete message");
+      }
+    },
+    [refreshMessages]
+  );
+
+  const handleRemoveAll = useCallback(() => {
+    if (messages.length === 0) {
+      Alert.alert("Info", "No messages to delete");
+      return;
+    }
+    Alert.alert(
+      "Remove All Messages",
+      `Are you sure you want to delete all ${messages.length} messages?`,
+      [
+        { text: "Cancel", style: "cancel" },
+        {
+          text: "Delete All",
+          style: "destructive",
+          onPress: async () => {
+            try {
+              const ids = messages.map((m) => m.appCardId);
+              console.log("[INSIDER][AppCards]: Deleting all " + ids.length + " cards");
+              await Insider.appCards.delete(ids);
+              Alert.alert("Success", "All messages deleted");
+              await refreshMessages();
+            } catch (err) {
+              console.log("[INSIDER][AppCards]: Error deleting all cards: " + err);
+              Alert.alert("Error", err instanceof Error ? err.message : "Failed to delete messages");
+            }
+          },
+        },
+      ]
+    );
+  }, [messages, refreshMessages]);
+
+  const viewedRef = useRef<Set<string>>(new Set());
+  const viewabilityConfig = useRef({ itemVisiblePercentThreshold: 50 }).current;
+  const onViewableItemsChanged = useRef(({ viewableItems }: { viewableItems: ViewToken[] }) => {
+    viewableItems.forEach(({ item }) => {
+      const card = item as InsiderAppCard;
+      if (card && !viewedRef.current.has(card.appCardId)) {
+        viewedRef.current.add(card.appCardId);
+        console.log("[INSIDER][AppCardItem]: View tracked: " + card.appCardId);
+        card.view();
+      }
+    });
+  }).current;
+
+  if (loading) {
+    return <Text style={[styles.stateText, stateTextColor]}>Loading...</Text>;
+  } else if (error) {
+    return <Text style={[styles.stateText, stateTextColor]}>{error.message}</Text>;
+  }
+
+  return (
+    <View style={styles.container}>
+      {messages.length > 0 && (
+        <View style={styles.removeAllWrapper}>
+          <CustomButton
+            text="Remove All"
+            buttonStyle={{ backgroundColor: Colors.coral }}
+            onPress={handleRemoveAll}
+          />
+        </View>
+      )}
+      <FlatList
+        data={messages}
+        keyExtractor={(item) => item.appCardId}
+        renderItem={({ item }) => (
+          <AppCardItem
+            item={item}
+            isDarkMode={isDarkMode}
+            onOpenDetail={handleOpenDetail}
+            onToggleRead={handleToggleRead}
+            onDelete={handleDelete}
+          />
+        )}
+        onViewableItemsChanged={onViewableItemsChanged}
+        viewabilityConfig={viewabilityConfig}
+        ListEmptyComponent={<Text style={[styles.emptyText, stateTextColor]}>No messages</Text>}
+      />
+
+      {selectedCard && (
+        <CardDetail
+          card={selectedCard}
+          isDarkMode={isDarkMode}
+          onClose={() => setSelectedCard(null)}
+          onToggleRead={handleToggleRead}
+          onDelete={handleDelete}
+        />
+      )}
+    </View>
+  );
+};
+
+function AppCards() {
+  const isDarkMode = useColorScheme() === "dark";
+  const [visible, setVisible] = useState(false);
+
+  return (
+    <View>
+      <CustomButton text="Show App Cards" onPress={() => setVisible(true)} />
+
+      <ModalScreen
+        visible={visible}
+        title="App Cards"
+        isDarkMode={isDarkMode}
+        onClose={() => setVisible(false)}
+      >
+        {visible && <AppCardsInbox isDarkMode={isDarkMode} />}
+      </ModalScreen>
+    </View>
+  );
+}
+
+export default AppCards;
+
+const styles = StyleSheet.create({
+  modalContainer: {
+    flex: 1,
+  },
+  modalHeader: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    paddingHorizontal: 20,
+    paddingVertical: 14,
+    borderBottomWidth: 1,
+  },
+  modalTitle: {
+    fontSize: 24,
+    fontWeight: "bold",
+  },
+  closeButton: {
+    paddingVertical: 6,
+    paddingHorizontal: 8,
+  },
+  closeIcon: {
+    fontSize: 20,
+    fontWeight: "600",
+    lineHeight: 22,
+  },
+  stateText: {
+    textAlign: "center",
+    marginTop: 20,
+    fontSize: 16,
+  },
+  container: {
+    flex: 1,
+  },
+  removeAllWrapper: {
+    flexDirection: "row",
+    paddingHorizontal: 15,
+    paddingTop: 8,
+  },
+  card: {
+    paddingHorizontal: 20,
+    paddingVertical: 14,
+    borderBottomWidth: 1,
+  },
+  cardHeader: {
+    flexDirection: "row",
+    alignItems: "center",
+    marginBottom: 4,
+  },
+  unreadIndicator: {
+    width: 8,
+    height: 8,
+    borderRadius: 4,
+    backgroundColor: Colors.blue,
+    marginRight: 8,
+  },
+  cardTitle: {
+    fontSize: 18,
+    fontWeight: "bold",
+    flex: 1,
+  },
+  cardBody: {
+    fontSize: 14,
+  },
+  emptyText: {
+    textAlign: "center",
+    marginTop: 20,
+    fontSize: 16,
+  },
+  buttonRow: {
+    flexDirection: "row",
+    marginTop: 8,
+  },
+  // --- Detail screen ---
+  detailScroll: {
+    padding: 20,
+  },
+  detailImage: {
+    width: "100%",
+    height: 180,
+    borderRadius: 8,
+    marginBottom: 16,
+  },
+  detailTitle: {
+    fontSize: 24,
+    fontWeight: "bold",
+  },
+  detailBody: {
+    fontSize: 16,
+    lineHeight: 24,
+    marginTop: 10,
+  },
+  detailCardButtons: {
+    marginTop: 16,
+  },
+  detailFooter: {
+    paddingHorizontal: 15,
+    paddingVertical: 12,
+    borderTopWidth: 1,
+  },
+});


### PR DESCRIPTION
## Summary
Adds a new **App Cards** demo section to the React Native Insider SDK demo, exercising the `Insider.appCards` API end to end.

- **`src/insider/AppCards.tsx`** (new): full-screen App Cards inbox (`FlatList` of cards) + a card detail view.
  - SDK surface demonstrated: `getCampaigns`, `markAsRead` / `markAsUnread`, `delete`, bulk `appCards.delete` (Remove All), and viewability tracking (`card.view()`).
  - Inbox and detail share one `ModalScreen` for the modal chrome (header + Close); per-card colors and the campaign fetch are factored into single helpers.
- **`App.tsx`**: wires it in as a new `App Cards` `CustomSection`, between Message Center and Content Optimizer.
- **`package.json` / `package-lock.json`**: pin `react` / `@types/react` / `react-test-renderer` to `19.1.x`.

## Verification
Ran the app on a real Android emulator and iOS simulator against the post-change Metro bundle:

- **Android (emulator-5554)** — driven end to end via `adb`: section renders in the right place → "Show App Cards" opens the inbox modal (header + Remove All + `FlatList` of live campaigns) → "Mark Read" toggles and the list refreshes → tapping a card opens the detail view (Open / Mark Unread / Delete) → ✕ returns to the inbox. No red box.
- **iOS (iPhone 17 Pro, 26.1)** — app launches and renders cleanly (no red box); Metro `index.bundle?platform=ios` compiles (HTTP 200, no errors, contains the new screen). Modal not interactively driven on iOS (no sim input tooling available in this environment); the modal code is shared RN JS, fully exercised on Android.

## Notes
- The default `__tests__/App-test.tsx` fails to run due to a **pre-existing** jest/babel transform config issue (`react-native/index.js` ESM not transformed) — unrelated to this change; no jest config was touched. `tsc --noEmit` is clean for the new file.
- A local-only `partnerName` test value and the untracked `.orbit-output/` directory are intentionally **not** included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
